### PR TITLE
Configure the mypy type checker in CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,6 +36,12 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+    - name: Run type checker
+      run: |
+        pip install -r requirements-types.txt
+        mypy || true
+
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Run type checker
       run: |
         pip install -r requirements-types.txt
-        mypy || true
+        mypy --non-interactive || true
 
     - name: Test with pytest
       run: |

--- a/connectome_interpreter/activation_maximisation.py
+++ b/connectome_interpreter/activation_maximisation.py
@@ -710,8 +710,8 @@ def input_from_df(df: pd.DataFrame, sensory_indices: list, idx_to_group: dict, n
 
 def get_neuron_activation(output: torch.Tensor | npt.NDArray,
                           neuron_indices: arrayable,
-                          batch_names: arrayable = None,
-                          idx_to_group: dict = None) -> pd.DataFrame:
+                          batch_names: arrayable | None = None,
+                          idx_to_group: dict | None = None) -> pd.DataFrame:
     """
     Get the activations for specified indices across timepoints, include
     batch name and group information when available.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,12 @@ version = {attr = "connectome_interpreter._version.__version__"}
 
 [tool.setuptools.packages.find]
 where = ["."]
+
+[tool.mypy]
+packages = ["connectome_interpreter", "tests"]
+install_types = true
+follow_untyped_imports = false
+pretty = true
+show_error_context = true
+show_column_numbers = true
+show_error_code_links = true

--- a/requirements-types.txt
+++ b/requirements-types.txt
@@ -1,0 +1,4 @@
+# Packages for the type checker
+pandas-stubs
+scipy-stubs
+types-tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@
 
 # Additional developer requirements here
 flake8
+mypy
 pytest


### PR DESCRIPTION
For now there will be a bunch of type errors, so CI is configured to report them but to otherwise pass (and run the unit tests).