### PR TITLE
Use actions/setup-python@v5

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
         cache: 'pip' # caching pip dependencies, https://github.com/actions/setup-python#caching-packages-dependencies


### PR DESCRIPTION
Per https://github.com/actions/setup-python/issues/1085
Should resolve the recent build failures

Test plan: CI should pass