### PR TITLE
mypy to ignore untyped imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,9 @@ addopts = ""  # Add arguments here
 [tool.mypy]
 packages = ["connectome_interpreter", "tests"]
 install_types = true
+ignore_missing_imports = true
 follow_untyped_imports = false
 pretty = true
 show_error_context = true
 show_column_numbers = true
 show_error_code_links = true
-


### PR DESCRIPTION
We won't be getting type hints on certain third-party libraries any time soon... so let's reduce the noise from mypy.

Test plan: No more errors from untyped imports.