### PR TITLE
add verbose kwarg to result_summary to silence startup print

### DIFF
--- a/connectome_interpreter/_version.py
+++ b/connectome_interpreter/_version.py
@@ -1,4 +1,4 @@
-__version__ = "2.10.0"
+__version__ = "2.11.0"
 # If you're making a patch or a minor bug fix, increment the patch version,
 # e.g., from 0.1.0 to 0.1.1.
 # If you're adding functionality in a backwards-compatible manner, increment

--- a/connectome_interpreter/compress_paths.py
+++ b/connectome_interpreter/compress_paths.py
@@ -422,7 +422,6 @@ def compress_paths_dense_chunked(
 
     with torch.no_grad():
         for i in tqdm(range(step_number)):
-
             if i == 0:
                 out_tensor = torch.tensor(inprop.toarray(), dtype=dtype)
             else:
@@ -1308,6 +1307,7 @@ def result_summary(
     include_undefined_groups: bool = False,
     outprop: bool = False,
     combining_method: str = "mean",
+    verbose: bool = True,
 ):
     """Generates a summary of connections between different types of neurons,
     represented by their input and output indexes. The function calculates the
@@ -1350,6 +1350,8 @@ def result_summary(
         combining_method (str, optional): Method to combine inputs (outprop=False)
             or outputs (outprop=True). Can be 'sum', 'mean', or 'median'.
             Defaults to 'mean'.
+        verbose (bool, optional): Whether to print informational messages.
+            Defaults to True.
 
     Returns:
         pd.DataFrame:
@@ -1365,9 +1367,10 @@ def result_summary(
         "The combining_method should be either 'mean', 'median', or 'sum'. "
         f"Currently it is {combining_method}."
     )
-    print(
-        "Feel free to try `connectivity_summary()` - the same function with less memory usage!"
-    )
+    if verbose:
+        print(
+            "Feel free to try `connectivity_summary()` - the same function with less memory usage!"
+        )
 
     if inidx_map is None:
         inidx_map = {idx: idx for idx in range(stepsn.shape[0])}

--- a/tests/test_compress_paths.py
+++ b/tests/test_compress_paths.py
@@ -933,6 +933,35 @@ class TestResultSummary(unittest.TestCase):
         self.all_indices = [0, 1, 2, 3, 4, 5, 6, 7, 8]
         self.subset_indices = [1, 3, 7]
 
+    def test_verbose_default_prints_message(self):
+        """By default (verbose=True) the informational message is printed."""
+        with patch("builtins.print") as mock_print:
+            result_summary(
+                self.test_matrix,
+                self.all_indices,
+                self.all_indices,
+                self.inidx_map,
+                self.outidx_map,
+                display_output=False,
+            )
+        self.assertTrue(mock_print.called)
+        printed = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("connectivity_summary", printed)
+
+    def test_verbose_false_silences_message(self):
+        """verbose=False suppresses the informational message."""
+        with patch("builtins.print") as mock_print:
+            result_summary(
+                self.test_matrix,
+                self.all_indices,
+                self.all_indices,
+                self.inidx_map,
+                self.outidx_map,
+                display_output=False,
+                verbose=False,
+            )
+        mock_print.assert_not_called()
+
     def test_basic_functionality_dense(self):
         """Test basic functionality with dense matrix."""
         result = result_summary(


### PR DESCRIPTION
Gate the unconditional 'try connectivity_summary()' message behind a new verbose (default True) parameter so downstream callers can opt out. Related to #37.